### PR TITLE
revert getpoolink function updates

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -56,13 +56,13 @@ export function getTimeframe(timeWindow) {
 export function getPoolLink(token0Address, token1Address = null, remove = false) {
   if (!token1Address) {
     return (
-      `https://sparkswap.finance/#/swap/page/` +
+      `https://sparkswap.finance/#/` +
       (remove ? `remove` : `add`) +
       `/${token0Address === '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' ? 'ETH' : token0Address}/${'ETH'}`
     )
   } else {
     return (
-      `https://sparkswap.finance/#/swap/page/` +
+      `https://sparkswap.finance/#/` +
       (remove ? `remove` : `add`) +
       `/${token0Address === '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' ? 'ETH' : token0Address}/${token1Address === '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' ? 'ETH' : token1Address
       }`


### PR DESCRIPTION
- Revert getPoolLink function hot fix
- Verify add liquidity functions
- Resolves: Link token pair selected when adding liquidity #34

![revert-getpoolink](https://user-images.githubusercontent.com/50922758/134104259-e47e6eb8-c459-43ad-8ab2-b1267f0372f3.gif)


